### PR TITLE
Add function to print error message and clean up code

### DIFF
--- a/tmpmail
+++ b/tmpmail
@@ -34,6 +34,10 @@ TMPMAIL_EMAIL_ADDRESS="$TMPMAIL_DIR/email_address"
 # are able to open this file
 TMPMAIL_HTML_EMAIL="$TMPMAIL_DIR/tmpmail.html"
 
+
+# Default 1secmail API URL
+TMPMAIL_API_URL="https://www.1secmail.com/api/v1/"
+
 usage() {
     # Using 'cat << EOF' we can easily output a multiline text. This is much
     # better than using 'echo' for each line or using '\n' to create a new line.
@@ -64,14 +68,13 @@ generate_email_address() {
     #      be empty as the newly generated email address has not been
     #      sent any emails.
     #
-    # When the function 'generate_email()' is called with the arguement
+    # When the function 'generate_email_address()' is called with the arguement
     # 'true', it means that the function was called because the user
     # ran 'tmpmail --generate'.
     #
     # We need this variable so we can know whether or not we need to show the user
     # what the email was. <-- More about this can be found further down in this function.
     EXTERNALLY=${1:-false}
-    CUSTOM=${2:-false}
 
     # This variable lets generate_email_address know if the user has provided a custom
     # email address which they want to use
@@ -105,13 +108,14 @@ generate_email_address() {
 
         # Do a regex check to see if the email address provided by the user is a
         # valid email address
-        echo "$EMAIL_ADDRESS" | grep -E "[a-z]+@1secmail\.(com|net|org)" >/dev/null
+        local regexp="[a-z]+@1secmail\.(com|net|org)"
+        grep -E "$regexp" <<< "$EMAIL_ADDRESS" >/dev/null
 
         # Get the exit status of the command above
         STATUS=$?
 
         [[ "$STATUS" -ne 0 ]] \
-            && print_error "Provided email is invalid. Must match [a-z]+@1secmail.(com|net|org)"
+            && print_error "Provided email is invalid. Must match $regexp"
     fi
 
     # Save the generated email address to the $TMPMAIL_EMAIL_ADDRESS file
@@ -139,7 +143,7 @@ list_emails() {
     # List all the received emails in a nicely formatted order
     #
     # Fetch the email data using 1secmail's API
-    DATA=$(curl -sL "https://1secmail.com/api/v1/?action=getMessages&login=$USERNAME&domain=1secmail.$TLD")
+    DATA=$(curl -sL "${TMPMAIL_API_URL}?action=getMessages&login=$USERNAME&domain=1secmail.$TLD")
 
     # Using 'jq' we get the length of the JSON data. From this we can determine whether or not
     # the email address has gotten any emails
@@ -212,13 +216,13 @@ view_email() {
     # The first argument provided to this function will be the ID of the email
     # that has been received
     EMAIL_ID="$1"
-    DATA=$(curl -sL "https://www.1secmail.com/api/v1/?action=readMessage&login=$USERNAME&domain=1secmail.$TLD&id=$EMAIL_ID")
+    DATA=$(curl -sL "${TMPMAIL_API_URL}?action=readMessage&login=$USERNAME&domain=1secmail.$TLD&id=$EMAIL_ID")
 
     # After the data is retrieved using the API, we have to check if we got any emails.
     # Luckly 1secmail's API is not complicated and returns 'Message not found' as plain text
     # if our email address as not received any emails.
-    # If we the error message from the API just quit because there is nothing to do
-    [[ "$DATA" == "Message not found" ]] && echo "Message not found" && exit 1
+    # If we received the error message from the API just quit because there is nothing to do
+    [[ "$DATA" == "Message not found" ]] && print_error "Message not found"
 
     # We pass the $DATA to 'jq' which extracts the values
     FROM=$(jq -r ".from" <<<"$DATA")
@@ -248,7 +252,6 @@ EOF
     # Open up the HTML file using $BROWSER. By default,
     # this will be 'w3m'.
     $BROWSER "$TMPMAIL_HTML_EMAIL"
-
 }
 
 view_recent_email() {

--- a/tmpmail
+++ b/tmpmail
@@ -107,14 +107,13 @@ generate_email_address() {
 
         # Do a regex check to see if the email address provided by the user is a
         # valid email address
-        regexp="[a-z]+@1secmail\.(com|net|org)"
-        printf "%b" "$EMAIL_ADDRESS" | grep -E "$regexp" >/dev/null
+        REGEXP="[a-z]+@1secmail\.(com|net|org)"
+        printf "%b" "$EMAIL_ADDRESS" | grep -E "$REGEXP" >/dev/null
 
         # Get the exit status of the command above
         STATUS=$?
 
-        [ "$STATUS" -ne 0 ] \
-            && print_error "Provided email is invalid. Must match $regexp"
+        [ "$STATUS" -ne 0 ] && print_error "Provided email is invalid. Must match $REGEXP"
     fi
 
     # Save the generated email address to the $TMPMAIL_EMAIL_ADDRESS file

--- a/tmpmail
+++ b/tmpmail
@@ -103,17 +103,15 @@ generate_email_address() {
     if [ "$CUSTOM" != false ]; then
         EMAIL_ADDRESS=$CUSTOM
 
-        # Do a regex check to see if the email address provided by the user is a 
+        # Do a regex check to see if the email address provided by the user is a
         # valid email address
         echo "$EMAIL_ADDRESS" | grep -E "[a-z]+@1secmail\.(com|net|org)" >/dev/null
-        
+
         # Get the exit status of the command above
         STATUS=$?
 
-        if [ "$STATUS" -ne 0 ]; then
-            echo "Error: Provided email is invalid. Must match [a-z]+@1secmail.(com|net|org)"
-            exit 1
-        fi
+        [[ "$STATUS" -ne 0 ]] \
+            && print_error "Provided email is invalid. Must match [a-z]+@1secmail.(com|net|org)"
     fi
 
     # Save the generated email address to the $TMPMAIL_EMAIL_ADDRESS file
@@ -264,14 +262,21 @@ view_recent_email() {
     view_email "$MAIL_ID"
 }
 
+
+print_error() {
+    # Print error message
+    #
+    # The first argument provided to this function will be the error message.
+    # Script will exit after printing the error message.
+    printf "%s\n" "Error: $1" >&2
+    exit 1
+}
+
 main() {
     # Iterate of the array of dependencies and check if the user has them installed
     dependencies=(jq w3m curl)
     for dependency in "${dependencies[@]}"; do
-        if ! has "$dependency"; then
-            echo "Error: Could not find '${dependency}', is it installed?" >&2
-            exit 1
-        fi
+        ! has "$dependency" && print_error "Could not find '${dependency}', is it installed?"
     done
 
     # Create the $TMPMAIL_DIR directory and dont throw any errors

--- a/tmpmail
+++ b/tmpmail
@@ -34,7 +34,6 @@ TMPMAIL_EMAIL_ADDRESS="$TMPMAIL_DIR/email_address"
 # are able to open this file
 TMPMAIL_HTML_EMAIL="$TMPMAIL_DIR/tmpmail.html"
 
-
 # Default 1secmail API URL
 TMPMAIL_API_URL="https://www.1secmail.com/api/v1/"
 
@@ -108,13 +107,13 @@ generate_email_address() {
 
         # Do a regex check to see if the email address provided by the user is a
         # valid email address
-        local regexp="[a-z]+@1secmail\.(com|net|org)"
+        regexp="[a-z]+@1secmail\.(com|net|org)"
         printf "%b" "$EMAIL_ADDRESS" | grep -E "$regexp" >/dev/null
 
         # Get the exit status of the command above
         STATUS=$?
 
-        [[ "$STATUS" -ne 0 ]] \
+        [ "$STATUS" -ne 0 ] \
             && print_error "Provided email is invalid. Must match $regexp"
     fi
 
@@ -266,7 +265,6 @@ view_recent_email() {
     view_email "$MAIL_ID"
 }
 
-
 print_error() {
     # Print error message
     #
@@ -316,7 +314,7 @@ main() {
                 # the email that belongs to the ID
                 view_email "$1" && exit
                 ;;
-            -*) echo "Error: option '$1' does not exist" ;;
+            -*) print_error "option '$1' does not exist" ;;
         esac
         shift
     done


### PR DESCRIPTION
In this PR:
1) Add function `print_error` to print error message and exit script after printing
2) Remove duplicated variable declaration of `CUSTOM=${2:-false} `
3) Define global variable `TMPMAIL_API_URL` as API URL
4) Define local variable `regexp` used as regex pattern
5) Make some `if` as one-liner
6) Fix some typos, clean tailing spaces and empty lines

Please review.