### PR TITLE
Made tmpmail POSIX compatible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,4 +20,4 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Run shellcheck
         run: |
-          shellcheck tmpmail
+          shellcheck -s sh tmpmail

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <h1 align="center">
   <img src="images/logo.png">
 </h1>
-<p align="center"> A temporary email right from your terminal</p><br>
+<p align="center"> A temporary email right from your terminal written in POSIX sh</p><br>
 
-<img src="images/demo.gif" align="right"> `tmpmail` is a command line utility that allows you to create a temporary email address
+<img src="images/demo.gif" align="right"> `tmpmail` is a command line utility written in POSIX `sh` that allows you to create a temporary email address
 and receive emails to the temporary email address. It uses 1secmail's [API](https://www.1secmail.com/api/)
 to receive emails.
 

--- a/tmpmail
+++ b/tmpmail
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh 
 #
 # by Siddharth Dushantha 2020
 #
@@ -91,11 +91,11 @@ generate_email_address() {
     # shellcheck disable=SC2018
     USERNAME=$(head /dev/urandom | tr -dc a-z | cut -c1-11)
 
-    # This is an array of the valid TLDS which 1secmail provides.
-    TLDS=(com net org)
-
+    # Valid TLDS which 1secmail provides.
+    TLDS="com net org"
+    
     # Randomly pick one of the TLDS mentiond above.
-    TLD=${TLDS[$RANDOM % ${#TLDS[@]}]}
+    TLD=$(printf "%b" "$TLDS" | tr " " "\n"| shuf -n 1)
 
     EMAIL_ADDRESS="$USERNAME@1secmail.$TLD"
 
@@ -105,7 +105,7 @@ generate_email_address() {
 
         # Do a regex check to see if the email address provided by the user is a 
         # valid email address
-        echo "$EMAIL_ADDRESS" | grep -E "[a-z]+@1secmail\.(com|net|org)" >/dev/null
+        printf "%b" "$EMAIL_ADDRESS" | grep -E "[a-z]+@1secmail\.(com|net|org)" >/dev/null
         
         # Get the exit status of the command above
         STATUS=$?
@@ -145,11 +145,11 @@ list_emails() {
 
     # Using 'jq' we get the length of the JSON data. From this we can determine whether or not
     # the email address has gotten any emails
-    DATA_LENGTH=$(jq length <<<"$DATA")
+    DATA_LENGTH=$(echo "$DATA" | jq length)
 
     # We are showing what email address is currently being used
     # in case the user has forgotten what the email address was.
-    echo -e "[ Inbox for $EMAIL_ADDRESS ]\n"
+    printf "[ Inbox for %s ]\n\n" "$EMAIL_ADDRESS"
 
     # If the length of the data we got is 0, that means the email address
     # has not received any emails yet.
@@ -157,7 +157,7 @@ list_emails() {
 
     # This is where we store all of our emails, which is then
     # displayed using 'column'
-    INBOX=()
+    INBOX=""
 
     # This for loop goes through each mail that have been received.
     #
@@ -191,21 +191,21 @@ list_emails() {
         # Since arrays in JSON data start at 0, we must subtract
         # the value of $index by 1 so that we dont miss one of the
         # emails in the array
-        MAIL_DATA=$(jq -r ".[$index-1]" <<<"$DATA")
+        MAIL_DATA=$(echo "$DATA" | jq -r ".[$index-1]")
 
-        ID=$(jq -r ".id" <<<"$MAIL_DATA")
-        FROM=$(jq -r ".from" <<<"$MAIL_DATA")
-        SUBJECT=$(jq -r ".subject" <<<"$MAIL_DATA")
+        ID=$(echo "$MAIL_DATA" | jq -r ".id")
+        FROM=$(echo "$MAIL_DATA" | jq -r ".from")
+    SUBJECT=$(echo "$MAIL_DATA" | jq -r ".subject")
 
         # The '||' are used as a divideder for 'column'. 'column' will use this divider as
         # a point of reference to create the division. By default 'column' uses a blank space
         # but that would not work in our case as the email subject could have multiple white spaces
         # and 'column' would split the words that are seperated by white space, in different columns.
-        INBOX+=("$ID ||$FROM ||$SUBJECT")
+        INBOX="$INBOX$ID ||$FROM ||$SUBJECT\n"
     done
 
     # Show the emails cleanly
-    column -t -s "||" < <(printf '%s\n' "${INBOX[@]}")
+    printf "%b" "$INBOX" | column -t -s "||"
 }
 
 view_email() {
@@ -220,26 +220,27 @@ view_email() {
     # Luckly 1secmail's API is not complicated and returns 'Message not found' as plain text
     # if our email address as not received any emails.
     # If we the error message from the API just quit because there is nothing to do
-    [[ "$DATA" == "Message not found" ]] && echo "Message not found" && exit 1
+    [ "$DATA" = "Message not found" ] && echo "Message not found" && exit 1
 
     # We pass the $DATA to 'jq' which extracts the values
-    FROM=$(jq -r ".from" <<<"$DATA")
-    SUBJECT=$(jq -r ".subject" <<<"$DATA")
-    HTML_BODY=$(jq -r ".htmlBody" <<<"$DATA")
+    FROM=$(echo "$DATA" | jq -r ".from")
+    SUBJECT=$(echo "$DATA" | jq -r ".subject")
+    HTML_BODY=$(echo "$DATA" | jq -r ".htmlBody")
 
     # If you get an email that is in pure text, the .htmlBody field will be empty and
     # we will need to get the content from .textBody instead
-    [ -z "$HTML_BODY" ] && HTML_BODY="<pre>$(jq -r ".textBody" <<<"$DATA")</pre>"
+    [ -z "$HTML_BODY" ] && HTML_BODY="<pre>$(echo "$DATA" | jq -r ".textBody")</pre>"
 
     # Create the HTML with all the information that is relevant and then
     # assigning that HTML to the variable HTML_MAIL. This is the best method
     # to create a multiline variable
-    read -r -d '' HTML_MAIL <<EOF
+    HTML_MAIL=$(cat <<EOF
 <pre><b>To: </b>$EMAIL_ADDRESS
 <b>From: </b>$FROM
 <b>Subject: </b>$SUBJECT</pre>
 $HTML_BODY
 EOF
+)
     # Save the $HTML_MAIL into $TMPMAIL_HTML_EMAIL
     echo "$HTML_MAIL" >"$TMPMAIL_HTML_EMAIL"
 
@@ -266,10 +267,9 @@ view_recent_email() {
 
 main() {
     # Iterate of the array of dependencies and check if the user has them installed
-    dependencies=(jq w3m curl)
-    for dependency in "${dependencies[@]}"; do
+    for dependency in jq w3m curl; do
         if ! has "$dependency"; then
-            echo "Error: Could not find '${dependency}', is it installed?" >&2
+            echo "Error: Could not find '$dependency', is it installed?" >&2
             exit 1
         fi
     done
@@ -292,9 +292,9 @@ main() {
     TLD=${EMAIL_ADDRESS#*.}
 
     # If no arguments are provided just the emails
-    [[ $# -eq 0 ]] && list_emails && exit
+    [ $# -eq 0 ] && list_emails && exit
 
-    while [[ "$1" ]]; do
+    while [ "$1" ]; do
         case "$1" in
             --help | -h) usage && exit ;;
             --generate | -g) generate_email_address true "$2" && exit ;;
@@ -308,7 +308,7 @@ main() {
                 # the email that belongs to the ID
                 view_email "$1" && exit
                 ;;
-            -*) echo "Error: option $1 does not exist" ;;
+            -*) echo "Error: option '$1' does not exist" ;;
         esac
         shift
     done


### PR DESCRIPTION
Rewrote some bits of `tmpmail` so it would be POSIX compliant. I used `shellcheck` to check for POSIX related errors and made changes according to those errors.

The main reason for why I am making `tmpmail` POSIX is so that I can learn how to write POSIX shell scripts and of course to support more platforms.