### PR TITLE
Fix -g error when email address having a digit before @

### DIFF
--- a/tmpmail
+++ b/tmpmail
@@ -107,7 +107,7 @@ generate_email_address() {
 
         # Do a regex check to see if the email address provided by the user is a
         # valid email address
-        REGEXP="[a-z]+@1secmail\.(com|net|org)"
+        REGEXP="[a-z0-9]+@1secmail\.(com|net|org)"
         printf "%b" "$EMAIL_ADDRESS" | grep -E "$REGEXP" >/dev/null
 
         # Get the exit status of the command above

--- a/tmpmail
+++ b/tmpmail
@@ -89,9 +89,7 @@ generate_email_address() {
     # So charcters such as dashes, periods, underscore, and numbers are all deleted,
     # giving us a text which only contains lower case letters form A to Z. We then take
     # the first 10 characters, which will be the username of the email address
-    #
-    # shellcheck disable=SC2018
-    USERNAME=$(head /dev/urandom | tr -dc a-z | cut -c1-11)
+    USERNAME=$(head /dev/urandom | tr -dc "[:alnum:]" | cut -c1-11)
 
     # Valid TLDS which 1secmail provides.
     TLDS="com net org"


### PR DESCRIPTION
Before this change, script shows regex error when generating email address containing a digit right befor `@`, e.g.: `./tmpmail -g xayrz1@1secmail.com`.

In this PR, regex is updated in order to allow digits in the email address.