### PR TITLE
I attempted to improve clarity, brevity, and correctness.

### DIFF
--- a/tmpmail
+++ b/tmpmail
@@ -4,10 +4,10 @@
 #
 # Dependencies: jq, curl, w3m
 #
-
+set -u  # enable interpreter to catch spelling mistakes of variables
 VERSION=1.1.2
 
-# By default 'tmpmail' uses 'w3m' as it's web browser to render
+# By default 'tmpmail' uses 'w3m' as its web browser to render
 # the HTML of the email
 BROWSER="w3m"
 
@@ -20,10 +20,10 @@ RAW_TEXT=false
 # restarting the computer
 TMPMAIL_DIR="/tmp/tmpmail"
 
-# TMPMAIL_EMAIL_ADDRESS is where we store the temporary email address
-# that gets generated. This prevents the user from providing
-# the email address everytime they run tmpmail
-TMPMAIL_EMAIL_ADDRESS="$TMPMAIL_DIR/email_address"
+# TMP_ADDRESS_FILE is where we store the temporary email address that gets
+# generated. This prevents the user from providing the email address
+# everytime tmpmail is run
+TMP_ADDRESS_FILE="$TMPMAIL_DIR/email_address"
 
 # tmpmail.html is where the email gets stored.
 # Even though the file ends with a .html extension, the raw text version of
@@ -34,10 +34,10 @@ TMPMAIL_HTML_EMAIL="$TMPMAIL_DIR/tmpmail.html"
 # Default 1secmail API URL
 TMPMAIL_API_URL="https://www.1secmail.com/api/v1/"
 
-usage() {
-    # Using 'cat << EOF' we can easily output a multiline text. This is much
-    # better than using 'echo' for each line or using '\n' to create a new line.
-    cat <<EOF
+# Making '{' the first character of a line makes it very easy to search for
+# the start of every function.  For example, grep '^{' or in less, /^\{
+usage()
+{ cat <<EOF
 tmpmail
 tmpmail -h | --version
 tmpmail -g [ADDRESS]
@@ -65,7 +65,8 @@ shows the email message with specified ID.
 EOF
 }
 
-generate_email_address() {
+generate_email_address()
+{
     # There are 2 ways which this function is called in this script.
     #  [1] The user wants to generate a new email and runs 'tmpmail --generate'
     #  [2] The user runs 'tmpmail' to check the inbox , but /tmp/tmpmail/email_address
@@ -74,7 +75,7 @@ generate_email_address() {
     #      be empty as the newly generated email address has not been
     #      sent any emails.
     #
-    # When the function 'generate_email_address()' is called with the arguement
+    # When the function 'generate_email_address()' is called with the argument
     # 'true', it means that the function was called because the user
     # ran 'tmpmail --generate'.
     #
@@ -83,159 +84,97 @@ generate_email_address() {
     EXTERNALLY=${1:-false}
 
     # This variable lets generate_email_address know if the user has provided a custom
-    # email address which they want to use
+    # email address which (s)he wants to use
     CUSTOM=${2:-false}
 
     # Generate a random email address.
     # This function is called whenever the user wants to generate a new email
     # address by running 'tmpmail --generate' or when the user runs 'tmpmail'
     # but /tmp/tmpmail/email_address is empty or nonexistent.
-    #
-    # We create a random username by taking the first 10 lines from /dev/random
-    # and delete all the characters which are *not* lower case letters from A to Z.
-    # So charcters such as dashes, periods, underscore, and numbers are all deleted,
-    # giving us a text which only contains lower case letters form A to Z. We then take
-    # the first 10 characters, which will be the username of the email address
-    USERNAME=$(head /dev/urandom | LC_ALL=C tr -dc "[:alnum:]" | cut -c1-11 | tr "[:upper:]" "[:lower:]")
 
-    # Valid TLDS which 1secmail provides.
-    TLDS="com net org"
-
-    # Randomly pick one of the TLDS mentiond above.
-    TLD=$(printf "%b" "$TLDS" | tr " " "\n"| shuf -n 1)
-
-    EMAIL_ADDRESS="$USERNAME@1secmail.$TLD"
+    # Valid top level domains which 1secmail provides
+    TLDS="com|net|org"
 
     # If the user provided a custom email address then use that email address
     if [ "$CUSTOM" != false ]; then
-        EMAIL_ADDRESS=$CUSTOM
-
-        # Do a regex check to see if the email address provided by the user is a
-        # valid email address
-        REGEXP="[a-z0-9]+@1secmail\.(com|net|org)"
-        if ! printf %b "$EMAIL_ADDRESS" | grep -Eq "$REGEXP"; then
-            print_error "Provided email is invalid. Must match $REGEXP"
-        fi
+        EMAIL_ADDRESS="$CUSTOM"
+    else  # Create a random username
+        # Take first 10 lines from /dev/urandom; delete all characters
+        # which are *not* alphanumeric (exclude punctuation etc.); take the
+        # first 10 characters; convert uppercase to lowercase
+        USERNAME=$(head /dev/urandom | LC_ALL=C tr -dc "[:alnum:]" | head -c10 | tr "[:upper:]" "[:lower:]")
+        # Randomly pick one of the TLDS mentiond above.
+        TLD=$(printf %s "$TLDS" | tr '|' '\n' | shuf -n 1)
+        EMAIL_ADDRESS="$USERNAME@1secmail.$TLD"
     fi
 
-    # Save the generated email address to the $TMPMAIL_EMAIL_ADDRESS file
-    # so that it can be whenever 'tmpmail' is run
-    printf %s "$EMAIL_ADDRESS" >"$TMPMAIL_EMAIL_ADDRESS"
+    # Check that the email address is valid
+    REGEXP="[a-z0-9]+@1secmail\.($TLDS)"
+    if ! printf %s "$EMAIL_ADDRESS" | grep -Eq "$REGEXP"; then
+        print_error "Email address '$EMAIL_ADDRESS' is invalid; it must match regexp '$REGEXP'."
+    fi
+
+    # Save the generated email address to $TMP_ADDRESS_FILE so that it can
+    # be read whenever 'tmpmail' is run
+    printf %s "$EMAIL_ADDRESS" >"$TMP_ADDRESS_FILE"
 
     # If this function was called because the user wanted to generate a new
-    # email address, show them the email address
-    [ "$EXTERNALLY" = true ] && cat "$TMPMAIL_EMAIL_ADDRESS"
+    # email address, show the email address
+    [ "$EXTERNALLY" = true ] && cat "$TMP_ADDRESS_FILE"
 }
 
-get_email_address() {
+get_email_address()
+{
     # This function is only called once and that is when this script
     # get executed. The output of this function gets stored in $EMAIL_ADDRESS
     #
     # If the file that contains the email address is empty,
     # that means we do not have an email address, so generate one.
-    [ ! -s "$TMPMAIL_EMAIL_ADDRESS" ] && generate_email_address
+    [ ! -s "$TMP_ADDRESS_FILE" ] && generate_email_address
 
     # Output the email address by getting the first line of $TMPMAIL_EMAIL
-    head -n 1 "$TMPMAIL_EMAIL_ADDRESS"
+    head -n 1 "$TMP_ADDRESS_FILE"
 }
 
-list_emails() {
-    # List all the received emails in a nicely formatted order
-    #
-    # Fetch the email data using 1secmail's API
+# List all the received emails in a nicely formatted order
+list_emails()
+{
     DATA=$(curl -sL "${TMPMAIL_API_URL}?action=getMessages&login=$USERNAME&domain=1secmail.$TLD")
-
-    # Using 'jq' we get the length of the JSON data. From this we can determine whether or not
-    # the email address has gotten any emails
-    DATA_LENGTH=$(printf %s "$DATA" | jq length)
-
-    # We are showing what email address is currently being used
-    # in case the user has forgotten what the email address was.
+    DATA_LENGTH=$(printf %s "$DATA" | jq length)  # number of messages
     printf "[ Inbox for %s ]\n\n" "$EMAIL_ADDRESS"
-
-    # If the length of the data we got is 0, that means the email address
-    # has not received any emails yet.
     [ "$DATA_LENGTH" -eq 0 ] && echo "No new mail" && exit
 
     # This is where we store all of our emails, which is then
     # displayed using 'column'
     INBOX=""
-
-    # This for loop goes through each mail that have been received.
-    #
-    # Since we need to go through all the data, we need to tell our for loop
-    # to loop from 1 to X, where X is legnth of the $DATA which contains all
-    # the emails.
-    #
-    # Normally to loop from 1 to 5, we would use shell expansion and write:
-    #   for index in {1..5}; do
-    #       do_something
-    #   done
-    #
-    # But we a minor issue. We dont know what the final number is, and we are not allowed
-    # use to variables in shell expansions like this:
-    #   {1..$X}
-    #
-    # where $X is the length of the $DATA.
-    #
-    # To fix this issue, we can use 'seq' which will allow us to create a sequence
-    # from X to Y.
-    # Example:
-    #  $ seq 1 5
-    #  1
-    #  2
-    #  3
-    #  4
-    #  5
-    #
-    # We can then put those results into the foor loop
     for index in $(seq 1 "$DATA_LENGTH"); do
-        # Since arrays in JSON data start at 0, we must subtract
-        # the value of $index by 1 so that we dont miss one of the
-        # emails in the array
+        # arrays in JSON start at 0, so subtract one from $index
         MAIL_DATA=$(printf %s "$DATA" | jq -r ".[$index-1]")
 
-        ID=$(printf %s "$MAIL_DATA" | jq -r ".id")
-        FROM=$(printf %s "$MAIL_DATA" | jq -r ".from")
+        ID=$(     printf %s "$MAIL_DATA" | jq -r ".id")
+        FROM=$(   printf %s "$MAIL_DATA" | jq -r ".from")
         SUBJECT=$(printf %s "$MAIL_DATA" | jq -r ".subject")
 
-        # The '||' are used as a divideder for 'column'. 'column' will use this divider as
-        # a point of reference to create the division. By default 'column' uses a blank space
-        # but that would not work in our case as the email subject could have multiple white spaces
-        # and 'column' would split the words that are seperated by white space, in different columns.
         INBOX="$INBOX$ID ||$FROM ||$SUBJECT\n"
     done
-
-    # Show the emails cleanly
     printf "%b" "$INBOX" | column -t -s "||"
 }
 
-view_email() {
-    # View an email by providing it's ID
-    #
-    # The first argument provided to this function will be the ID of the email
-    # that has been received
+# Arg 1 ($1) is the ID of the email message
+view_email()
+{
     EMAIL_ID="$1"
     DATA=$(curl -sL "${TMPMAIL_API_URL}?action=readMessage&login=$USERNAME&domain=1secmail.$TLD&id=$EMAIL_ID")
-
-    # After the data is retrieved using the API, we have to check if we got any emails.
-    # Luckly 1secmail's API is not complicated and returns 'Message not found' as plain text
-    # if our email address as not received any emails.
-    # If we received the error message from the API just quit because there is nothing to do
     [ "$DATA" = "Message not found" ] && print_error "Message not found"
 
-    # We pass the $DATA to 'jq' which extracts the values
-    FROM=$(printf %s "$DATA" | jq -r ".from")
-    SUBJECT=$(printf %s "$DATA" | jq -r ".subject")
+    FROM=$(     printf %s "$DATA" | jq -r ".from")
+    SUBJECT=$(  printf %s "$DATA" | jq -r ".subject")
     HTML_BODY=$(printf %s "$DATA" | jq -r ".htmlBody")
 
     # If you get an email that is in pure text, the .htmlBody field will be empty and
     # we will need to get the content from .textBody instead
     [ -z "$HTML_BODY" ] && HTML_BODY="<pre>$(printf %s "$DATA" | jq -r ".textBody")</pre>"
 
-    # Create the HTML with all the information that is relevant and then
-    # assigning that HTML to the variable HTML_MAIL. This is the best method
-    # to create a multiline variable
     HTML_MAIL=$(cat <<EOF
 <pre><b>To: </b>$EMAIL_ADDRESS
 <b>From: </b>$FROM
@@ -243,51 +182,30 @@ view_email() {
 $HTML_BODY
 EOF
 )
-    # Save the $HTML_MAIL into $TMPMAIL_HTML_EMAIL
-    printf %s "$HTML_MAIL" >"$TMPMAIL_HTML_EMAIL"
-
-    # If the '--text' flag is used, then use 'w3m' to convert the HTML of
-    # the email to pure text by removing all the HTML tags
-    [ "$RAW_TEXT" = true ] && w3m -dump "$TMPMAIL_HTML_EMAIL" && exit
-
-    # Open up the HTML file using $BROWSER. By default,
-    # this will be 'w3m'.
-    $BROWSER "$TMPMAIL_HTML_EMAIL"
+    printf %s "$HTML_MAIL" > "$TMPMAIL_HTML_EMAIL"
+    if [ "$RAW_TEXT" = true ]; then
+        w3m -dump "$TMPMAIL_HTML_EMAIL"
+    else
+        $BROWSER "$TMPMAIL_HTML_EMAIL"
+    fi
 }
 
-view_recent_email() {
-    # View the most recent email.
-    #
-    # This is done by listing all the received email like you
-    # normally see on the terminal when running 'tmpmail'.
-    # We then grab the ID of the most recent
-    # email, which the first line.
-    MAIL_ID=$(list_emails | head -3 | tail -1 | cut -d' ' -f 1)
-    view_email "$MAIL_ID"
-}
+view_latest_email()
+{ view_email $(list_emails | sed -n 3p | cut -d' ' -f 1); }
 
-print_error() {
-    # Print error message
-    #
-    # The first argument provided to this function will be the error message.
-    # Script will exit after printing the error message.
-    printf "%s\n" "Error: $1" >&2
-    exit 1
-}
+# Arg 1 ($1) is the error message to print to stderr
+print_error()
+{ printf "%s: Error: %s\n" "$0" "$1" >&2; exit 1; }
 
-main() {
-    # Iterate of the array of dependencies and check if the user has them installed
-    for dependency in jq w3m curl; do
+main()
+{
+    for dependency in jq w3m curl; do   # required programs
         if ! command -v "$dependency" >/dev/null 2>&1; then
             print_error "Could not find '$dependency', is it installed?"
         fi
     done
 
-    # Create the $TMPMAIL_DIR directory and dont throw any errors
-    # if it already exists
     mkdir -p "$TMPMAIL_DIR"
-
-    # Get the email address and save the value to the EMAIL_ADDRESS variable
     EMAIL_ADDRESS="$(get_email_address)"
 
     # ${VAR#PATTERN} Removes shortest match of pattern from start of a string.
@@ -297,30 +215,44 @@ main() {
 
     # ${VAR%PATTERN} Remove shortest match of pattern from end of a string.
     # In this case, it takes the EMAIL_ADDRESS and removes everything until the
-    # period '.' which gives us the TLD
+    # period '.' which gives us the Top Level Domain
     TLD=${EMAIL_ADDRESS#*.}
 
-    # If no arguments are provided just the emails
-    [ $# -eq 0 ] && list_emails && exit
-
-    while [ "$1" ]; do
+    while [ $# -gt 0 ]; do
         case "$1" in
-            --help | -h) usage && exit ;;
-            --generate | -g) generate_email_address true "$2" && exit ;;
-            --browser | -b) BROWSER="$2" ;;
-            --text | -t) RAW_TEXT=true ;;
-            --version) echo "$VERSION" && exit ;;
-            --recent | -r) view_recent_email && exit ;;
+            --browser | -b)
+                if [ $# -ge 2 ]; then BROWSER="$2"; shift
+                else print_error "option $1 is missing its argument"
+                fi ;;
+            --generate | -g)
+                [ $# -ge 2 ] && addr="$2" || addr=""
+                generate_email_address true "$addr"
+                exit ;;
+            --help | -h)
+                usage
+                exit ;;
+            --recent | -r)
+                view_latest_email
+                exit ;;
+            --text | -t)
+                RAW_TEXT=true ;;
+            --version)
+                echo "$VERSION"
+                exit ;;
+            -*)
+                print_error "unrecognized option '$1'" ;;
             *[0-9]*)
                 # If the user provides number as an argument,
-                # assume its the ID of an email and try getting
+                # assume it is the ID of an email and try getting
                 # the email that belongs to the ID
-                view_email "$1" && exit
-                ;;
-            -*) print_error "option '$1' does not exist" ;;
+                view_email "$1"
+                exit ;;
+            *)
+                print_error "unrecognized argument '$1'" ;;
         esac
         shift
     done
+    list_emails
 }
 
 main "$@"


### PR DESCRIPTION
- set -u to check for correctness
- correct spelling mistakes & grammar in comments
- more specific variable name
- removed comments explaining basic unix commands and shell features,
  like here document, seq, column
- removed comments that only restate what the code obviously does
- put braces marking function beginning on first column
- renamed view_recent_email() to view_latest_email() because it is shorter than
  view_most_recent_email
- added command name ($0) to output of print_error()
- more robust checking for options and arguments to options