### PR TITLE
'util-linux' package added for column utility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM alpine
 
 RUN apk -U upgrade
 
-RUN apk --no-cache add curl jq w3m
-
+RUN apk --no-cache add curl jq w3m \
+    util-linux # for "columns" binary
 
 RUN curl -L "https://git.io/tmpmail" > tmpmail && chmod +x tmpmail
-
 
 RUN mv tmpmail /bin/


### PR DESCRIPTION
Oops! I jus ran the program and when I went to check in the email I got error like this "column: command not found" or something like that. And was scratching my head until I noticed I had forgotten to add 'util-linux' package which provides a 'columns' binary in alpine. I hope this didn't interpret anyone's workflow.

I also didn't notice any time difference when building the image.