### PR TITLE
Dockerfile & Readme updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM alpine
+FROM alpine:3.15.3
 
 RUN apk -U upgrade
 
 RUN apk --no-cache add curl jq w3m \
+    xclip # doesnot work because it requires X server \
     util-linux # for "columns" binary
 
 RUN curl -L "https://git.io/tmpmail" > tmpmail && chmod +x tmpmail

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ use the `--browser` argument followed by the command needed to launch the web br
 - `w3m`
 - `curl`
 - [`jq`](https://github.com/stedolan/jq)
+- `xclip`
 
 ## Installation
 ### Install locally
@@ -58,7 +59,7 @@ requirements:
 
 ```bash                                                                                        
 $ docker build -t mail .; # Dockerfile available in source code
-$ docker run -it mail /bin/bash; 
+$ docker run -it mail;
 ```   
 
 ## Usage


### PR DESCRIPTION
- Added `xclip` dependency in Dockerfile.
- Added `xclip` in dependency tab in Readme.
- Alpine doesn't use `bash` therefore removed `/bin/bash` from docker run command in Readme.