### PR TITLE
chore: remove git.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ use the `--browser` argument followed by the command needed to launch the web br
 
 ```bash
 # Download the tmpmail file and make it executable
-$ curl -L "https://git.io/tmpmail" > tmpmail && chmod +x tmpmail
+$ curl -L "https://raw.githubusercontent.com/sdushantha/tmpmail/master/tmpmail" > tmpmail && chmod +x tmpmail
 
 # Then move it somewhere in your $PATH. Here is an example:
 $ mv tmpmail ~/bin/


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/