### PR TITLE
Get list of available domains direct from API instead of hardcoded list

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ shows the email message with specified ID.
         clipboard (default: xclip -selection c)
 -c, --copy
         Copy the email address to your clipboard
+-d, --domains
+        Show list of available domains
 -g, --generate [ADDRESS]
         Generate a new email address, either the specified ADDRESS, or
         randomly create one

--- a/tmpmail
+++ b/tmpmail
@@ -85,13 +85,14 @@ get_list_of_domains() {
     # If the length of the data we got is 0, that means the email address
     # has not received any emails yet.
     [ "$data_length" -eq 0 ] && echo "1secmail API error for getting domains list" && exit
+
     # Getting rid of quotes, braces and replace comma with space
-    printf "${data//[\"\[\]]/}" | tr "," " "
+    printf "%s" "$data" | tr -d "[|]|\"" | tr "," " "
 }
 
 show_list_of_domains() {
-    domains=$(get_list_of_domains)
-    printf "List of available domains: \n%s\n" "${domains//\ /$'\n'}"
+    domains=$(printf "%s" "$(get_list_of_domains)" | tr " " "\n")
+    printf "List of available domains: \n%s\n" "$domains"
 }
 
 generate_email_address() {
@@ -129,8 +130,8 @@ generate_email_address() {
 
     # Getting list of available domains into $domains variable
     domains=$(get_list_of_domains)
-    
-    valid_email_address_regex="[a-z0-9]+@(${domains//\ /\|})"
+
+    valid_email_address_regex=$(printf "[a-z0-9]+@%s" "$domains" | tr " " "|")
     username_black_list_regex="(abuse|webmaster|contact|postmaster|hostmaster|admin)"
     username_black_list="- abuse\n- webmaster\n- contact\n- postmaster\n- hostmaster\n- admin"
 

--- a/tmpmail
+++ b/tmpmail
@@ -79,6 +79,7 @@ EOF
 get_list_of_domains() {
     # Getting domains list from 1secmail API
     data=$(curl -sL "$tmpmail_api_url?action=getDomainList") 
+
     # Number of available domains
     data_length=$(printf %s "$data" | jq length)
 
@@ -91,7 +92,9 @@ get_list_of_domains() {
 }
 
 show_list_of_domains() {
-    domains=$(printf "%s" "$(get_list_of_domains)" | tr " " "\n")
+    # Convert the list of domains which are in a singal line, into multiple lines
+    # with a dash in the beginning of each domain for a clean output
+    domains=$(printf "%s" "$(get_list_of_domains)" | tr " " "\n" | sed "s/^/- /g")
     printf "List of available domains: \n%s\n" "$domains"
 }
 
@@ -128,10 +131,8 @@ generate_email_address() {
     # the first 10 characters, which will be the username of the email address
     username=$(head /dev/urandom | LC_ALL=C tr -dc "[:alnum:]" | cut -c1-11 | tr "[:upper:]" "[:lower:]")
 
-    # Getting list of available domains into $domains variable
-    domains=$(get_list_of_domains)
-
-    valid_email_address_regex=$(printf "[a-z0-9]+@%s" "$domains" | tr " " "|")
+    # Generate a regex for valif email adress by fetching the list of supported domains
+    valid_email_address_regex=$(printf "[a-z0-9]+@%s" "$(get_list_of_domains | tr ' ' '|')")
     username_black_list_regex="(abuse|webmaster|contact|postmaster|hostmaster|admin)"
     username_black_list="- abuse\n- webmaster\n- contact\n- postmaster\n- hostmaster\n- admin"
 

--- a/tmpmail
+++ b/tmpmail
@@ -59,6 +59,8 @@ shows the email message with specified ID.
         clipboard (default: xclip -selection c)
 -c, --copy
         Copy the email address to your clipboard
+-d, --domains
+        Show list of available domains
 -g, --generate [ADDRESS]
         Generate a new email address, either the specified ADDRESS, or
         randomly create one
@@ -72,6 +74,24 @@ shows the email message with specified ID.
 --version
         Show version
 EOF
+}
+
+get_list_of_domains() {
+    # Getting domains list from 1secmail API
+    data=$(curl -sL "$tmpmail_api_url?action=getDomainList") 
+    # Number of available domains
+    data_length=$(printf %s "$data" | jq length)
+
+    # If the length of the data we got is 0, that means the email address
+    # has not received any emails yet.
+    [ "$data_length" -eq 0 ] && echo "1secmail API error for getting domains list" && exit
+    # Getting rid of quotes, braces and replace comma with space
+    domains=$(printf "${data//[\"\[\]]/}" | tr "," " ")
+}
+
+show_list_of_domains() {
+    get_list_of_domains
+    printf "List of available domains: \n%s\n" "${domains//\ /$'\n'}"
 }
 
 generate_email_address() {
@@ -110,7 +130,9 @@ generate_email_address() {
     valid_email_address_regex="[a-z0-9]+@(1secmail\.(com|net|org)|esiix.co|wwjmp.com|xojxe.com|yoggm.com)"
     username_black_list_regex="(abuse|webmaster|contact|postmaster|hostmaster|admin)"
     username_black_list="- abuse\n- webmaster\n- contact\n- postmaster\n- hostmaster\n- admin"
-    domains="1secmail.com 1secmail.net 1secmail.org esiix.com wwjmp.com xojxe.com yoggm.com" 
+
+    # Getting list of available domains into $domains variable
+    get_list_of_domains
 
     # Randomly pick one of the domains mentioned above.
     domain=$(printf "%b" "$domains" | tr " " "\n" | randomize | tail -1)
@@ -356,6 +378,7 @@ main() {
     while [ "$1" ]; do
         case "$1" in
             --help | -h) usage && exit ;;
+            --domains | -d) show_list_of_domains && exit ;;
             --generate | -g) generate_email_address true "$2" && exit ;;
             --clipboard-cmd) copy_to_clipboard_cmd="$2" ;;
             --copy | -c) copy_email_to_clipboard && exit ;;

--- a/tmpmail
+++ b/tmpmail
@@ -86,11 +86,11 @@ get_list_of_domains() {
     # has not received any emails yet.
     [ "$data_length" -eq 0 ] && echo "1secmail API error for getting domains list" && exit
     # Getting rid of quotes, braces and replace comma with space
-    domains=$(printf "${data//[\"\[\]]/}" | tr "," " ")
+    printf "${data//[\"\[\]]/}" | tr "," " "
 }
 
 show_list_of_domains() {
-    get_list_of_domains
+    domains=$(get_list_of_domains)
     printf "List of available domains: \n%s\n" "${domains//\ /$'\n'}"
 }
 
@@ -132,7 +132,7 @@ generate_email_address() {
     username_black_list="- abuse\n- webmaster\n- contact\n- postmaster\n- hostmaster\n- admin"
 
     # Getting list of available domains into $domains variable
-    get_list_of_domains
+    domains=$(get_list_of_domains)
 
     # Randomly pick one of the domains mentioned above.
     domain=$(printf "%b" "$domains" | tr " " "\n" | randomize | tail -1)

--- a/tmpmail
+++ b/tmpmail
@@ -127,12 +127,12 @@ generate_email_address() {
     # the first 10 characters, which will be the username of the email address
     username=$(head /dev/urandom | LC_ALL=C tr -dc "[:alnum:]" | cut -c1-11 | tr "[:upper:]" "[:lower:]")
 
-    valid_email_address_regex="[a-z0-9]+@(1secmail\.(com|net|org)|esiix.co|wwjmp.com|xojxe.com|yoggm.com)"
-    username_black_list_regex="(abuse|webmaster|contact|postmaster|hostmaster|admin)"
-    username_black_list="- abuse\n- webmaster\n- contact\n- postmaster\n- hostmaster\n- admin"
-
     # Getting list of available domains into $domains variable
     domains=$(get_list_of_domains)
+    
+    valid_email_address_regex="[a-z0-9]+@(${domains//\ /\|})"
+    username_black_list_regex="(abuse|webmaster|contact|postmaster|hostmaster|admin)"
+    username_black_list="- abuse\n- webmaster\n- contact\n- postmaster\n- hostmaster\n- admin"
 
     # Randomly pick one of the domains mentioned above.
     domain=$(printf "%b" "$domains" | tr " " "\n" | randomize | tail -1)


### PR DESCRIPTION
This fix implements 2 functions:
 - *get_list_of_domains* which receives list of available domains direct from API
 - *show_list_of_domains* which shows list of domains in case of *-d* option