### PR TITLE
chore: remove git.io #72

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
-FROM alpine:3.15.3
+FROM alpine:3.15.4
 
-RUN apk -U upgrade
+RUN apk --no-cache add curl jq w3m xclip util-linux
 
-RUN apk --no-cache add curl jq w3m \
-    xclip # doesnot work because it requires X server \
-    util-linux # for "columns" binary
-
-RUN curl -L "https://git.io/tmpmail" > tmpmail && chmod +x tmpmail
+RUN curl -L "https://raw.githubusercontent.com/sdushantha/tmpmail/master/tmpmail" > tmpmail && chmod +x tmpmail
 
 RUN mv tmpmail /bin/


### PR DESCRIPTION
- GitHub link updated.
- Not necessary to upgrade Alpine each time if using latest image.
- Basic cleaning.